### PR TITLE
Prevent spurious migrations that change auto field

### DIFF
--- a/src/wagtail_vector_index/apps.py
+++ b/src/wagtail_vector_index/apps.py
@@ -5,3 +5,4 @@ class WagtailVectorIndexAppConfig(AppConfig):
     label = "wagtail_vector_index"
     name = "wagtail_vector_index"
     verbose_name = "Wagtail Vector Index"
+    default_auto_field = "django.db.models.AutoField"

--- a/src/wagtail_vector_index/backends/pgvector/apps.py
+++ b/src/wagtail_vector_index/backends/pgvector/apps.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class PgvectorConfig(AppConfig):
     name = "wagtail_vector_index.backends.pgvector"
     verbose_name = _("pgvector")
+    default_auto_field = "django.db.models.AutoField"
 
     # TODO: Check if we're using a Postgres database.
     #       Otherwise this app should not be allowed.


### PR DESCRIPTION
If a Django project defines `DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"` (which is the recommended configuration for new projects), it's going to generate two migrations for `wagtail_vector_index` and `wagtail_vector_index.backends.pgvector` (see below). By setting `AppConfig.default_auto_field` we prevent this.

```diff
diff --git a/src/wagtail_vector_index/backends/pgvector/migrations/0003_alter_pgvectorembedding_id.py b/src/wagtail_vector_index/backends/pgvector/migrations/0003_alter_pgvectorembedding_id.py
new file mode 100644
index 0000000..6bebc7a
--- /dev/null
+++ b/src/wagtail_vector_index/backends/pgvector/migrations/0003_alter_pgvectorembedding_id.py
@@ -0,0 +1,20 @@
+# Generated by Django 4.2.9 on 2024-01-08 14:18
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pgvector", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="pgvectorembedding",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False
+            ),
+        ),
+    ]
diff --git a/src/wagtail_vector_index/migrations/0002_alter_embedding_id.py b/src/wagtail_vector_index/migrations/0002_alter_embedding_id.py
new file mode 100644
index 0000000..d2ca7f9
--- /dev/null
+++ b/src/wagtail_vector_index/migrations/0002_alter_embedding_id.py
@@ -0,0 +1,20 @@
+# Generated by Django 4.2.9 on 2024-01-08 14:18
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtail_vector_index", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="embedding",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False
+            ),
+        ),
+    ]
```