### PR TITLE
Check type annotations in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .'[testing,llm,numpy,pgvector,qdrant,weaviate]'
       - uses: jakebailey/pyright-action@v1
         with:
           version: 1.1.345

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
+      - uses: jakebailey/pyright-action@v1
+        with:
+          version: 1.1.345
 
   test-sqlite:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With your preferred virtualenv activated, install testing dependencies:
 
 ```sh
 python -m pip install --upgrade pip>=21.3
-python -m pip install -e .[testing] -U
+python -m pip install -e .'[testing,llm,numpy,pgvector,qdrant,weaviate]' -U
 ```
 
 #### Using flit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ testing = [
     "wagtail-factories>=4.1.0",
     "factory-boy>=3.3.0",
     "coverage>=7.0,<8.0",
+    "pyright>=1.1.345",
+    "django-types>=0.19.1",
 ]
 docs = [
     "mkdocs>=1.5.3",
@@ -91,3 +93,12 @@ pythonpath = ["./", "./tests"]
 [tool.ruff]
 select = ["F", "E", "C90", "I", "B", "DJ", "RUF", "TRY", "C4", "TCH005", "TCH004"]
 ignore = ["TRY003", "E501", "RUF012"]
+
+[tool.pyright]
+include = ["src/**"]
+exclude = [
+    "**/migrations",
+    "src/wagtail_vector_index/backends/qdrant/backend.py",
+]
+pythonVersion = "3.11"
+typeCheckingMode = "basic"

--- a/src/wagtail_vector_index/ai.py
+++ b/src/wagtail_vector_index/ai.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from .ai_utils.backends import BackendSettingsDict
+from .ai_utils.backends import BackendSettingsDict, EmbeddingBackendSettingsDict
 from .ai_utils.backends import get_chat_backend as get_chat_backend_instance
 from .ai_utils.backends import (
     get_embedding_backend as get_embedding_backend_instance,
@@ -28,7 +28,7 @@ def get_chat_backends_settings() -> Mapping[str, BackendSettingsDict]:
     }
 
 
-def get_embedding_backends_settings() -> Mapping[str, BackendSettingsDict]:
+def get_embedding_backends_settings() -> Mapping[str, EmbeddingBackendSettingsDict]:
     try:
         return settings.WAGTAIL_VECTOR_INDEX["EMBEDDING_BACKENDS"]
     except (KeyError, AttributeError) as e:

--- a/src/wagtail_vector_index/ai_utils/backends/__init__.py
+++ b/src/wagtail_vector_index/ai_utils/backends/__init__.py
@@ -13,6 +13,7 @@ from .base import (
     BaseChatBackend,
     BaseConfigSettingsDict,
     BaseEmbeddingBackend,
+    BaseEmbeddingConfigSettingsDict,
 )
 
 
@@ -37,7 +38,7 @@ class ChatBackendSettingsDict(BackendSettingsDict):
 
 
 class EmbeddingBackendSettingsDict(BackendSettingsDict):
-    pass
+    CONFIG: Required[BaseEmbeddingConfigSettingsDict]
 
 
 def _validate_backend_settings(
@@ -152,5 +153,8 @@ def get_embedding_backend(
 ) -> BaseEmbeddingBackend:
     return cast(
         BaseEmbeddingBackend,
-        _get_backend(backend_dict=backend_dict, backend_id=backend_id),
+        _get_backend(
+            backend_dict=backend_dict,  # type: ignore
+            backend_id=backend_id,
+        ),
     )

--- a/src/wagtail_vector_index/ai_utils/backends/base.py
+++ b/src/wagtail_vector_index/ai_utils/backends/base.py
@@ -33,7 +33,7 @@ class BaseChatConfigSettingsDict(BaseConfigSettingsDict):
 
 
 class BaseEmbeddingConfigSettingsDict(BaseConfigSettingsDict):
-    EMBEDDING_OUTPUT_DIMENSIONS: int
+    EMBEDDING_OUTPUT_DIMENSIONS: NotRequired[int | None]
 
 
 ConfigSettings = TypeVar(
@@ -154,7 +154,7 @@ class BaseEmbeddingConfig(BaseConfig[EmbeddingConfigSettings]):
 
     @classmethod
     def get_embedding_output_dimensions(
-        cls, *, model_id: str, custom_value: int
+        cls, *, model_id: str, custom_value: int | None
     ) -> int:
         if custom_value is not None:
             try:

--- a/src/wagtail_vector_index/backends/weaviate/backend.py
+++ b/src/wagtail_vector_index/backends/weaviate/backend.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import weaviate
+from django.core.exceptions import ImproperlyConfigured
 
 from wagtail_vector_index.backends import Backend, Index, SearchResponseDocument
 from wagtail_vector_index.base import Document
@@ -54,6 +55,8 @@ class WeaviateBackend(Backend[BackendConfig, WeaviateIndex]):
 
     def __init__(self, config: Mapping[str, Any]) -> None:
         super().__init__(config)
+        if self.config.API_KEY is None:
+            raise ImproperlyConfigured("Weaviate API key is not set")
         auth_config = weaviate.auth.AuthApiKey(api_key=self.config.API_KEY)
         self.client = weaviate.Client(self.config.HOST, auth_client_secret=auth_config)
 

--- a/src/wagtail_vector_index/base.py
+++ b/src/wagtail_vector_index/base.py
@@ -52,7 +52,7 @@ class VectorIndexable(Protocol[VectorIndexableType]):
         """Convert a list of documents back to the objects they represent"""
         ...
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """
         Equality check has to be implemented for the vector index to work
         properly.

--- a/tests/test_ai_utils/test_tokens.py
+++ b/tests/test_ai_utils/test_tokens.py
@@ -11,5 +11,5 @@ def test_get_default_token_limit_for_unknown_model():
         tokens.get_default_token_limit("echo-123-16k")
 
 
-def test_get_default_chunk_overlap() -> int:
+def test_get_default_chunk_overlap():
     assert tokens.get_default_chunk_overlap() == 100

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -37,4 +37,4 @@ class DifferentPage(VectorIndexedMixin, Page):
 
 @registry.register()
 class MultiplePageVectorIndex(PageVectorIndex):
-    querysets = [ExamplePage.objects.all(), DifferentPage.objects.all()]
+    querysets = [ExamplePage.objects.all(), DifferentPage.objects.all()]  # type: ignore


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail-vector-index/issues/29

Pyright is configured to only run basic checks (`typeCheckingMode = "basic"`). It's not ideal, and there are a couple of places where I've added `# type: ignore`, but we can improve these over time.