### PR TITLE
Create the `PageVectorIndexedMixin` class

### DIFF
--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -6,23 +6,23 @@ A barebones implementation of `VectorIndex` needs to implement one method; `get_
 
 There are two ways to use Vector Indexes. Either:
 
--   Adding the `VectorIndexedMixin` to a Django model, which will automatically generate an Index for that model
+-   Adding the `PageVectorIndexedMixin` to a Wagtail Page model, or the `VectorIndexedMixin` to a plain Django model, which will automatically generate an Index for that model.
 -   Creating your own subclass of one of the `VectorIndex` classes.
 
-## Automatically Generating Indexes using `VectorIndexedMixin`
+## Automatically Generating Indexes using `PageVectorIndexedMixin` or `VectorIndexedMixin`
 
 To generate a Vector Index based on an existing model in your application:
 
-1. Add Wagtail AI's `VectorIndexedMixin` mixin to your model
-2. Set `embedding_fields` to a list of `EmbeddingField`s representing the fields you want to be included in the embeddings
+1. Add Wagtail AI's `PageVectorIndexedMixin` or `VectorIndexedMixin` mixin to your model.
+2. Set `embedding_fields` to a list of `EmbeddingField`s representing the fields you want to be included in the embeddings.
 
 ```python
 from django.db import models
 from wagtail.models import Page
-from wagtail_vector_index.index import VectorIndexedMixin, EmbeddingField
+from wagtail_vector_index.index import PageVectorIndexedMixin, EmbeddingField
 
 
-class MyPage(VectorIndexedMixin, Page):
+class MyPage(PageVectorIndexedMixin, Page):
     body = models.TextField()
 
     embedding_fields = [EmbeddingField("title"), EmbeddingField("body")]

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,16 +19,16 @@ This way, when you provide a query, we can use the same model to get an embeddin
 
 To index your models:
 
-1. Add Wagtail Vector Index's `VectorIndexedMixin` mixin to your model
-2. Set `embedding_fields` to a list of `EmbeddingField`s representing the fields you want to be included in the embeddings
+1. Add Wagtail Vector Index's `PageVectorIndexedMixin` mixin to your page model.
+2. Set `embedding_fields` to a list of `EmbeddingField`s representing the fields you want to be included in the embeddings.
 
 ```python
 from django.db import models
 from wagtail.models import Page
-from wagtail_vector_index.models import VectorIndexedMixin, EmbeddingField
+from wagtail_vector_index.models import PageVectorIndexedMixin, EmbeddingField
 
 
-class MyPage(VectorIndexedMixin, Page):
+class MyPage(PageVectorIndexedMixin, Page):
     body = models.TextField()
 
     embedding_fields = [EmbeddingField("title"), EmbeddingField("body")]

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,7 +6,11 @@ from wagtail_vector_index.index.model import (
     PageVectorIndex,
 )
 from wagtail_vector_index.index.registry import registry
-from wagtail_vector_index.models import EmbeddingField, VectorIndexedMixin
+from wagtail_vector_index.models import (
+    EmbeddingField,
+    PageVectorIndexedMixin,
+    VectorIndexedMixin,
+)
 
 
 class ExampleModel(VectorIndexedMixin, models.Model):
@@ -19,7 +23,7 @@ class ExampleModel(VectorIndexedMixin, models.Model):
         return self.title
 
 
-class ExamplePage(VectorIndexedMixin, Page):
+class ExamplePage(PageVectorIndexedMixin, Page):
     body = RichTextField()
 
     content_panels = [*Page.content_panels, FieldPanel("body")]
@@ -27,7 +31,7 @@ class ExamplePage(VectorIndexedMixin, Page):
     embedding_fields = [EmbeddingField("title", important=True), EmbeddingField("body")]
 
 
-class DifferentPage(VectorIndexedMixin, Page):
+class DifferentPage(PageVectorIndexedMixin, Page):
     body = RichTextField()
 
     content_panels = [*Page.content_panels, FieldPanel("body")]


### PR DESCRIPTION
It's an explicit way to include Wagtail-specific behaviour (i.e. use of `PageVectorIndex` instead of `ModelVectorIndex`) when defining a Page model. This also helps with type annotations for the return value of the `get_vector_index()` method.