### PR TITLE
Install package in edit mode for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,12 +42,12 @@ deps =
 
     postgres:
         psycopg2>=2.9
-        .[pgvector]
+        -e .[pgvector]
 
     llm:
-        .[llm]
+        -e .[llm]
 
-    .[testing]
+    -e .[testing]
 
 commands = python -Im coverage run -m pytest {posargs}
 
@@ -75,7 +75,7 @@ basepython = python3.11
 deps =
     wagtail>=5.2
 
-    .[testing]
+    -e .[testing]
 
 commands_pre =
     python {toxinidir}/testmanage.py makemigrations


### PR DESCRIPTION
This makes development easier by having the tox virtualenv be up to date with code changes. Otherwise one has to rebuild the virtualenv after eveery change in order to reinstall wagtail-vector-index inside.