### PR TITLE
Make `object_type` be an attr of the index class

### DIFF
--- a/src/wagtail_vector_index/index/__init__.py
+++ b/src/wagtail_vector_index/index/__init__.py
@@ -8,4 +8,4 @@ from .registry import registry
 def get_vector_indexes() -> dict[str, VectorIndex]:
     register_indexed_models()
 
-    return {name: cls(object_type=cls) for name, cls in registry._registry.items()}
+    return {name: cls() for name, cls in registry._registry.items()}

--- a/src/wagtail_vector_index/index/base.py
+++ b/src/wagtail_vector_index/index/base.py
@@ -26,11 +26,11 @@ class VectorIndex(Generic[VectorIndexableType]):
 
     embedding_backend: BaseEmbeddingBackend
     chat_backend: BaseChatBackend
+    object_type: type[VectorIndexableType]
 
     def __init__(
         self,
         *,
-        object_type: type[VectorIndexableType],
         chat_backend_alias="default",
         embedding_backend_alias="default",
         vector_backend_alias="default",
@@ -41,7 +41,6 @@ class VectorIndex(Generic[VectorIndexableType]):
         self.chat_backend = get_chat_backend(chat_backend_alias)
         self.vector_backend = get_vector_backend(alias=vector_backend_alias)
         self.backend_index = self.vector_backend.get_index(self.__class__.__name__)
-        self.object_type = object_type
 
     def get_documents(self) -> Iterable[Document]:
         raise NotImplementedError

--- a/src/wagtail_vector_index/models.py
+++ b/src/wagtail_vector_index/models.py
@@ -256,5 +256,8 @@ class VectorIndexedMixin(models.Model):
         return type(
             f"{cls.__name__}Index",
             (index_cls,),
-            {"querysets": [cls.objects.all()]},
-        )(object_type=cls)
+            {
+                "querysets": [cls.objects.all()],
+                "object_type": cls,
+            },
+        )()

--- a/tests/test_model_index.py
+++ b/tests/test_model_index.py
@@ -22,6 +22,11 @@ class IndexOperations:
         results = index.search("")
         assert len(results) == 5
 
+    def test_query(self):
+        index = self.get_index()
+        results = index.query("")
+        assert len(results.sources) == 5
+
 
 class TestIndexOperationsFromModel(IndexOperations):
     def get_index(self):

--- a/tests/test_model_index.py
+++ b/tests/test_model_index.py
@@ -1,0 +1,33 @@
+import pytest
+from factories import ExamplePageFactory
+from testapp.models import ExamplePage
+from wagtail_vector_index.index import get_vector_indexes
+
+pytestmark = pytest.mark.django_db
+
+
+class IndexOperations:
+    """Common assertions for index operations"""
+
+    @pytest.fixture(autouse=True)
+    def setup_models(self):
+        ExamplePageFactory.create_batch(10)
+        ExamplePage.get_vector_index().rebuild_index()
+
+    def get_index(self):
+        raise NotImplementedError("Must be implemented in subclass")
+
+    def test_search(self):
+        index = self.get_index()
+        results = index.search("")
+        assert len(results) == 5
+
+
+class TestIndexOperationsFromModel(IndexOperations):
+    def get_index(self):
+        return ExamplePage.get_vector_index()
+
+
+class TestIndexOperationsFromRegistry(IndexOperations):
+    def get_index(self):
+        return get_vector_indexes()["ExamplePageIndex"]


### PR DESCRIPTION
This fixes the bug in https://github.com/wagtail/wagtail-vector-index/issues/18 where an index pulled from the registry is unable to perform `search()` and `query()` operations.