### PR TITLE
Refactor the registry to hold index instances

### DIFF
--- a/src/wagtail_vector_index/index/__init__.py
+++ b/src/wagtail_vector_index/index/__init__.py
@@ -8,4 +8,4 @@ from .registry import registry
 def get_vector_indexes() -> dict[str, VectorIndex]:
     register_indexed_models()
 
-    return {name: cls() for name, cls in registry._registry.items()}
+    return dict(registry._registry)

--- a/src/wagtail_vector_index/index/model.py
+++ b/src/wagtail_vector_index/index/model.py
@@ -75,4 +75,4 @@ def register_indexed_models():
         if issubclass(model, VectorIndexedMixin) and not model._meta.abstract
     ]
     for model in indexed_models:
-        registry.register()(model.get_vector_index().__class__)
+        registry.register_index(model.get_vector_index())

--- a/src/wagtail_vector_index/index/registry.py
+++ b/src/wagtail_vector_index/index/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .base import VectorIndex
@@ -8,14 +8,10 @@ class VectorIndexRegistry:
     """A registry to keep track of all the VectorIndex classes that have been registered."""
 
     def __init__(self):
-        self._registry: dict[str, Type["VectorIndex"]] = {}
+        self._registry: dict[str, "VectorIndex"] = {}
 
-    def register(self):
-        def decorator(cls: Type["VectorIndex"]):
-            self._registry[cls.__name__] = cls
-            return cls
-
-        return decorator
+    def register_index(self, index: "VectorIndex"):
+        self._registry[type(index).__name__] = index
 
     def __iter__(self):
         return iter(self._registry.items())

--- a/src/wagtail_vector_index/models.py
+++ b/src/wagtail_vector_index/models.py
@@ -9,7 +9,7 @@ from django.db import models, transaction
 from wagtail.models import Page
 from wagtail.search.index import BaseField
 
-from wagtail_vector_index.index.base import Document
+from wagtail_vector_index.index.base import Document, VectorIndex
 from wagtail_vector_index.index.exceptions import IndexedTypeFromDocumentError
 from wagtail_vector_index.index.model import (
     ModelVectorIndex,
@@ -240,7 +240,7 @@ class VectorIndexedMixin(models.Model):
             yield cls.from_document(document)
 
     @classmethod
-    def get_vector_index(cls):
+    def get_vector_index(cls) -> VectorIndex:
         """Get a vector index instance for this model"""
 
         # If the user has specified a custom `vector_index_class`, use that
@@ -260,4 +260,4 @@ class VectorIndexedMixin(models.Model):
                 "querysets": [cls.objects.all()],
                 "object_type": cls,
             },
-        )()
+        )()  # type: ignore

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -34,7 +34,7 @@ def test_indexed_model_has_vector_index():
 
 def test_register_custom_vector_index():
     custom_index = type("MyVectorIndex", (VectorIndex,), {})
-    registry.register()(custom_index)
+    registry.register_index(custom_index())
     index_classes = [index.__class__ for index in get_vector_indexes().values()]
     assert custom_index in index_classes
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -35,6 +35,8 @@ class DifferentPage(VectorIndexedMixin, Page):
     embedding_fields = [EmbeddingField("title", important=True), EmbeddingField("body")]
 
 
-@registry.register()
 class MultiplePageVectorIndex(PageVectorIndex):
     querysets = [ExamplePage.objects.all(), DifferentPage.objects.all()]  # type: ignore
+
+
+registry.register_index(MultiplePageVectorIndex())


### PR DESCRIPTION
This patch simplifies the index registry: instead of storing index classes, and creating instances on the fly, it stores index instances that are ready to use. A different approach to addressing https://github.com/wagtail/wagtail-vector-index/issues/18 (though it's orthogonal to https://github.com/wagtail/wagtail-vector-index/pull/51; we could merge both).

The main case for storing index classes seems to be the ability to use multiple indexes for a given model, e.g. for a different embedding or chat backend.
* A different embedding backend means different embeddings are generated, so running `./manage.py update_vector_indexes` should rebuild each set of embeddings. Therefore, it makes sense to register multiple indexes for the same model. With this patch, the model's `get_vector_index()` method would return the "default" index, and the user would call `registry.register_index()` with additional indexes.
* A different chat backend is ephemeral. Perhaps this should not be a parameter of the index itself. From reading the code, I can't figure out why this is even a concern of the vector index class.
