### PR TITLE
Move responsibility for text splitting configuration to the indexed type

### DIFF
--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -67,5 +67,5 @@ By default this is done by merging all `embedding_fields` together and then spli
 
 To customise this behaviour, either:
 
-- Override the `_get_text_splitter` method on a `VectorIndexedMixin` model, returning a class that conforms to the `TextSplitterProtocol`.
+- Override the `_get_text_splitter_class` method on a `VectorIndexedMixin` model, returning a class that conforms to the `TextSplitterProtocol`.
 - Override the `_get_split_content` method on a `VectorIndexedMixin` model to split your content however you want.

--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -65,13 +65,7 @@ Due to token limitations in AI models, content from indexed models is split up i
 
 By default this is done by merging all `embedding_fields` together and then splitting on new paragraphs, new lines, sentences and words (getting more specific as required) until it fits within a defined split size.
 
-To customise this behaviour, override the `_get_split_content` method on a `VectorIndexedMixin` model.
+To customise this behaviour, either:
 
-```python
-def _get_split_content(
-    self, *, split_length: int = 800, split_overlap: int = 100
-) -> List[str]:
-    return ["What? A swallow carrying a coconut?"]
-```
-
-It is up to your implementation to respect the requested `split_length` and `split_overlap`.
+- Override the `_get_text_splitter` method on a `VectorIndexedMixin` model, returning a class that conforms to the `TextSplitterProtocol`.
+- Override the `_get_split_content` method on a `VectorIndexedMixin` model to split your content however you want.

--- a/src/wagtail_vector_index/ai_utils/tokens.py
+++ b/src/wagtail_vector_index/ai_utils/tokens.py
@@ -26,7 +26,3 @@ def get_default_token_limit(model_id: str) -> int:
 
         case _:
             raise NoTokenLimitFound(model_id)
-
-
-def get_default_chunk_overlap() -> int:
-    return 100

--- a/src/wagtail_vector_index/models.py
+++ b/src/wagtail_vector_index/models.py
@@ -9,6 +9,7 @@ from django.db import models, transaction
 from wagtail.models import Page
 from wagtail.search.index import BaseField
 
+from wagtail_vector_index.ai_utils.types import TextSplitterProtocol
 from wagtail_vector_index.index.base import Document
 from wagtail_vector_index.index.exceptions import IndexedTypeFromDocumentError
 from wagtail_vector_index.index.model import (
@@ -112,9 +113,7 @@ class VectorIndexedMixin(models.Model):
         }
         return list(embedding_fields.values())
 
-    def _get_text_splitter(
-        self, chunk_size: int
-    ) -> LangchainRecursiveCharacterTextSplitter:
+    def _get_text_splitter_class(self, chunk_size: int) -> TextSplitterProtocol:
         length_calculator = NaiveTextSplitterCalculator()
         return LangchainRecursiveCharacterTextSplitter(
             chunk_size=chunk_size,
@@ -143,7 +142,7 @@ class VectorIndexedMixin(models.Model):
 
         text = "\n".join(splittable_content)
         important_text = "\n".join(important_content)
-        splitter = self._get_text_splitter(chunk_size=chunk_size)
+        splitter = self._get_text_splitter_class(chunk_size=chunk_size)
         return [f"{important_text}\n{text}" for text in splitter.split_text(text)]
 
     @classmethod

--- a/tests/test_ai_utils/test_text_splitting.py
+++ b/tests/test_ai_utils/test_text_splitting.py
@@ -1,83 +1,10 @@
 import pytest
-from wagtail_vector_index.ai_utils.backends import get_chat_backend
 from wagtail_vector_index.ai_utils.text_splitting.dummy import (
     DummyLengthCalculator,
-    DummyTextSplitter,
-)
-from wagtail_vector_index.ai_utils.text_splitting.langchain import (
-    LangchainRecursiveCharacterTextSplitter,
 )
 from wagtail_vector_index.ai_utils.text_splitting.naive import (
     NaiveTextSplitterCalculator,
 )
-
-
-def test_default_text_splitter():
-    chat_backend = get_chat_backend(
-        backend_dict={
-            "CLASS": "wagtail_vector_index.ai_utils.backends.echo.EchoChatBackend",
-            "CONFIG": {
-                "MODEL_ID": "echo",
-                "TOKEN_LIMIT": 1024,
-            },
-        },
-        backend_id="default",
-    )
-    text_splitter = chat_backend.get_text_splitter()
-    assert isinstance(text_splitter, LangchainRecursiveCharacterTextSplitter)
-
-
-def test_default_length_calculator():
-    chat_backend = get_chat_backend(
-        backend_dict={
-            "CLASS": "wagtail_vector_index.ai_utils.backends.echo.EchoChatBackend",
-            "CONFIG": {
-                "MODEL_ID": "echo",
-                "TOKEN_LIMIT": 1024,
-            },
-        },
-        backend_id="default",
-    )
-    length_calculator = chat_backend.get_splitter_length_calculator()
-    assert isinstance(length_calculator, NaiveTextSplitterCalculator)
-
-
-def test_custom_text_splitter():
-    chat_backend = get_chat_backend(
-        backend_dict={
-            "CLASS": "wagtail_vector_index.ai_utils.backends.echo.EchoChatBackend",
-            "CONFIG": {
-                "MODEL_ID": "echo",
-                "TOKEN_LIMIT": 1024,
-            },
-            "TEXT_SPLITTING": {
-                "SPLITTER_CLASS": "wagtail_vector_index.ai_utils.text_splitting.dummy.DummyTextSplitter"
-            },
-        },
-        backend_id="default",
-    )
-
-    text_splitter = chat_backend.get_text_splitter()
-    assert isinstance(text_splitter, DummyTextSplitter)
-
-
-def test_custom_length_calculator():
-    chat_backend = get_chat_backend(
-        backend_dict={
-            "CLASS": "wagtail_vector_index.ai_utils.backends.echo.EchoChatBackend",
-            "CONFIG": {
-                "MODEL_ID": "echo",
-                "TOKEN_LIMIT": 1024,
-            },
-            "TEXT_SPLITTING": {
-                "SPLITTER_LENGTH_CALCULATOR_CLASS": "wagtail_vector_index.ai_utils.text_splitting.dummy.DummyLengthCalculator"
-            },
-        },
-        backend_id="default",
-    )
-    length_calculator = chat_backend.get_splitter_length_calculator()
-    assert isinstance(length_calculator, DummyLengthCalculator)
-
 
 LENGTH_CALCULATOR_SAMPLE_TEXTS = [
     """Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/tests/test_ai_utils/test_tokens.py
+++ b/tests/test_ai_utils/test_tokens.py
@@ -9,7 +9,3 @@ def test_get_default_token_limit_for_known_model():
 def test_get_default_token_limit_for_unknown_model():
     with pytest.raises(tokens.NoTokenLimitFound, match="echo-123-16k"):
         tokens.get_default_token_limit("echo-123-16k")
-
-
-def test_get_default_chunk_overlap():
-    assert tokens.get_default_chunk_overlap() == 100

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -4,7 +4,6 @@ import pytest
 from factories import ExamplePageFactory
 from faker import Faker
 from testapp.models import ExamplePage
-from wagtail_vector_index.ai import get_embedding_backend
 from wagtail_vector_index.index import (
     VectorIndex,
     get_vector_indexes,
@@ -69,9 +68,7 @@ def test_get_split_content_adds_important_field_to_each_split(patch_embedding_fi
     ):
         body = fake.text(max_nb_chars=200)
         instance = ExamplePageFactory.create(title="Important Title", body=body)
-        splits = instance._get_split_content(
-            embedding_backend=get_embedding_backend("default")
-        )
+        splits = instance._get_split_content(chunk_size=100)
         assert all(split.startswith(instance.title) for split in splits)
 
 


### PR DESCRIPTION
Previously, the splitting behaviour was defined through settings on an embedding backend. If you want to split differently for different indexes, you'd need to create multiple embedding backends.

As the only thing that needs to be aware of how content is split is the `VectorIndexable` object itself, the logic has now moved there and any customisations can be made on the indexed type directly.