### PR TITLE
Restructure Documents to be dependent on Embeddings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ A `VectorIndex` uses the `Backend` configured as `default` in the Django setting
 
 ## `Document` - `index/base.py`
 
-`Document`s are a dataclass representing something that is stored in a `VectorIndex`. They have an identifier, a vector (for the embedding) and an unstructured metadata dict. This class allows us to store anything in a `VectorIndex` without needing to build indexes that hold specific types of object.
+`Document`s are a dataclass representing something that is stored in a `VectorIndex`. They have a reference to an Embedding database object, a vector (for the embedding) and an unstructured metadata dict. This class allows us to store anything in a `VectorIndex` without needing to build indexes that hold specific types of object.
 
 Whenever we are working with `VectorIndex`s, we are working with Document objects but as a user, these Documents aren't usually what we want to be working with. We would prefer to deal with our models and Pages, and let the package transparently handle converting them back and forth to Documents.
 

--- a/src/wagtail_vector_index/backends/base.py
+++ b/src/wagtail_vector_index/backends/base.py
@@ -1,0 +1,67 @@
+import copy
+from collections.abc import Generator, Iterable, Mapping, Sequence
+from typing import Any, Generic, TypeVar
+
+from django.core.exceptions import ImproperlyConfigured
+
+from wagtail_vector_index.index.base import Document, VectorIndex
+from wagtail_vector_index.index.registry import registry
+
+ConfigClass = TypeVar("ConfigClass")
+IndexClass = TypeVar("IndexClass", bound="Index")
+
+
+class Index:
+    def __init__(self, index_name: str, **kwargs: Any) -> None:
+        self.index_name = index_name
+
+    def get_vector_index(self) -> "VectorIndex":
+        return registry[self.index_name]()
+
+    def upsert(self, *, documents: Iterable["Document"]) -> None:
+        raise NotImplementedError
+
+    def clear(self) -> None:
+        raise NotImplementedError
+
+    def delete(self, *, document_ids: Sequence[str]) -> None:
+        raise NotImplementedError
+
+    def similarity_search(
+        self, query_vector: Sequence[float], *, limit: int = 5
+    ) -> Generator[Document, None, None]:
+        raise NotImplementedError
+
+
+class Backend(Generic[ConfigClass, IndexClass]):
+    config: ConfigClass
+    config_class: type[ConfigClass]
+    index_class: type[IndexClass]
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        try:
+            config = dict(copy.deepcopy(config))
+            self.config = self.config_class(**config)
+        except TypeError as e:
+            raise ImproperlyConfigured(
+                f"Missing configuration settings for the vector backend: {e}"
+            ) from e
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        try:
+            cls.config_class  # noqa: B018
+        except AttributeError as e:
+            raise AttributeError(
+                f"Vector backend {cls.__name__} must specify a `config_class` class \
+                    attribute"
+            ) from e
+        return super().__init_subclass__(**kwargs)
+
+    def get_index(self, index_name: str) -> IndexClass:
+        raise NotImplementedError
+
+    def create_index(self, index_name: str, *, vector_size: int) -> IndexClass:
+        raise NotImplementedError
+
+    def delete_index(self, index_name: str):
+        raise NotImplementedError

--- a/src/wagtail_vector_index/backends/numpy/backend.py
+++ b/src/wagtail_vector_index/backends/numpy/backend.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from wagtail_vector_index.backends import Backend, Index, SearchResponseDocument
+from wagtail_vector_index.backends.base import Backend, Index
 from wagtail_vector_index.index.base import Document
 
 logger = logging.Logger(__name__)
@@ -23,7 +23,7 @@ class NumpyIndex(Index):
 
     def similarity_search(
         self, query_vector: Sequence[float], *, limit: int = 5
-    ) -> Generator[SearchResponseDocument, None, None]:
+    ) -> Generator[Document, None, None]:
         similarities = []
         vector_index = self.get_vector_index()
         for document in vector_index.get_documents():
@@ -37,10 +37,8 @@ class NumpyIndex(Index):
         sorted_similarities = sorted(
             similarities, key=lambda pair: pair[0], reverse=True
         )
-        for similarity in [pair[1] for pair in sorted_similarities][:limit]:
-            yield SearchResponseDocument(
-                id=similarity.embedding_pk, metadata=similarity.metadata
-            )
+        for document in [pair[1] for pair in sorted_similarities][:limit]:
+            yield document
 
 
 class NumpyBackend(Backend[BackendConfig, NumpyIndex]):

--- a/src/wagtail_vector_index/backends/numpy/backend.py
+++ b/src/wagtail_vector_index/backends/numpy/backend.py
@@ -38,7 +38,9 @@ class NumpyIndex(Index):
             similarities, key=lambda pair: pair[0], reverse=True
         )
         for similarity in [pair[1] for pair in sorted_similarities][:limit]:
-            yield SearchResponseDocument(id=similarity.id, metadata=similarity.metadata)
+            yield SearchResponseDocument(
+                id=similarity.embedding_pk, metadata=similarity.metadata
+            )
 
 
 class NumpyBackend(Backend[BackendConfig, NumpyIndex]):

--- a/src/wagtail_vector_index/backends/pgvector/backend.py
+++ b/src/wagtail_vector_index/backends/pgvector/backend.py
@@ -3,7 +3,7 @@ from collections.abc import Generator, Iterable, MutableSequence, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
-from wagtail_vector_index.backends import Backend, Index, SearchResponseDocument
+from wagtail_vector_index.backends.base import Backend, Index
 from wagtail_vector_index.index.base import Document
 
 from .models import PgvectorEmbedding, PgvectorEmbeddingQuerySet
@@ -67,7 +67,7 @@ class PgvectorIndex(Index):
 
     def similarity_search(
         self, query_vector, *, limit: int = 5
-    ) -> Generator[SearchResponseDocument, None, None]:
+    ) -> Generator[Document, None, None]:
         for pgvector_embedding in (
             self._get_queryset()
             .select_related("embedding")
@@ -78,8 +78,7 @@ class PgvectorIndex(Index):
             .iterator()
         ):
             embedding = pgvector_embedding.embedding
-            doc = embedding.to_document()
-            yield SearchResponseDocument(id=doc.embedding_pk, metadata=doc.metadata)
+            yield embedding.to_document()
 
     def _get_queryset(self) -> PgvectorEmbeddingQuerySet:
         # objects is technically a Manager instance but we want to use the custom

--- a/src/wagtail_vector_index/backends/pgvector/backend.py
+++ b/src/wagtail_vector_index/backends/pgvector/backend.py
@@ -79,7 +79,7 @@ class PgvectorIndex(Index):
         ):
             embedding = pgvector_embedding.embedding
             doc = embedding.to_document()
-            yield SearchResponseDocument(id=doc.id, metadata=doc.metadata)
+            yield SearchResponseDocument(id=doc.embedding_pk, metadata=doc.metadata)
 
     def _get_queryset(self) -> PgvectorEmbeddingQuerySet:
         # objects is technically a Manager instance but we want to use the custom

--- a/src/wagtail_vector_index/backends/pgvector/backend.py
+++ b/src/wagtail_vector_index/backends/pgvector/backend.py
@@ -96,7 +96,7 @@ class PgvectorIndex(Index):
 
     def _document_to_embedding(self, document: Document) -> PgvectorEmbedding:
         return PgvectorEmbedding(
-            embedding_id=document.id,
+            embedding_id=document.embedding_pk,
             embedding_output_dimensions=len(document.vector),
             vector=document.vector,
             index_name=self.index_name,

--- a/src/wagtail_vector_index/backends/qdrant/backend.py
+++ b/src/wagtail_vector_index/backends/qdrant/backend.py
@@ -25,7 +25,7 @@ class QdrantIndex(Index):
     def upsert(self, *, documents: Iterable[Document]) -> None:
         points = [
             qdrant_models.PointStruct(
-                id=document.id,
+                id=document.embedding_pk,
                 vector=document.vector,
                 payload=document.metadata,
             )

--- a/src/wagtail_vector_index/backends/qdrant/backend.py
+++ b/src/wagtail_vector_index/backends/qdrant/backend.py
@@ -5,7 +5,7 @@ from typing import Any
 from qdrant_client import QdrantClient
 from qdrant_client.http import models as qdrant_models
 
-from wagtail_vector_index.backends import Backend, Index, SearchResponseDocument
+from wagtail_vector_index.backends.base import Backend, Index
 from wagtail_vector_index.index.base import Document
 
 
@@ -41,12 +41,14 @@ class QdrantIndex(Index):
 
     def similarity_search(
         self, query_vector: Sequence[float], *, limit: int = 5
-    ) -> Generator[SearchResponseDocument, None, None]:
+    ) -> Generator[Document, None, None]:
         similar_documents = self.client.search(
             collection_name=self.index_name, query_vector=query_vector, limit=limit
         )
         for doc in similar_documents:
-            yield SearchResponseDocument(id=doc["id"], metadata=doc["payload"])
+            yield Document(
+                embedding_pk=doc["id"], vector=doc["vector"], metadata=doc["payload"]
+            )
 
 
 class QdrantBackend(Backend[BackendConfig, QdrantIndex]):

--- a/src/wagtail_vector_index/index/base.py
+++ b/src/wagtail_vector_index/index/base.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import ClassVar, Protocol
+from uuid import UUID
 
 from django.conf import settings
 
@@ -9,16 +10,19 @@ from wagtail_vector_index.ai_utils.backends.base import BaseEmbeddingBackend
 from wagtail_vector_index.backends import get_vector_backend
 
 
-@dataclass
+@dataclass(kw_only=True, frozen=True)
 class Document:
     """Representation of some content that is passed to vector storage backends.
 
     A document is usually a part of a model, e.g. some content split out from
     a VectorIndexedMixin model. One model instance may have multiple documents.
+
+    The embedding_pk on a Document must be the PK of an Embedding model instance.
     """
 
-    id: str
+    id: UUID
     vector: Sequence[float]
+    embedding_pk: int
     metadata: Mapping
 
 

--- a/src/wagtail_vector_index/index/base.py
+++ b/src/wagtail_vector_index/index/base.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import ClassVar, Protocol
-from uuid import UUID
 
 from django.conf import settings
 
@@ -20,7 +19,6 @@ class Document:
     The embedding_pk on a Document must be the PK of an Embedding model instance.
     """
 
-    id: UUID
     vector: Sequence[float]
     embedding_pk: int
     metadata: Mapping

--- a/src/wagtail_vector_index/index/models.py
+++ b/src/wagtail_vector_index/index/models.py
@@ -1,4 +1,3 @@
-import uuid
 from collections.abc import Generator, Iterable, MutableSequence, Sequence
 from typing import (
     ClassVar,
@@ -94,7 +93,6 @@ class Embedding(models.Model):
 
     def to_document(self) -> Document:
         return Document(
-            id=uuid.uuid4(),
             vector=self.vector,
             embedding_pk=self.pk,
             metadata={

--- a/src/wagtail_vector_index/index/models.py
+++ b/src/wagtail_vector_index/index/models.py
@@ -1,3 +1,4 @@
+import uuid
 from collections.abc import Generator, Iterable, MutableSequence, Sequence
 from typing import (
     ClassVar,
@@ -93,8 +94,9 @@ class Embedding(models.Model):
 
     def to_document(self) -> Document:
         return Document(
-            id=str(self.pk),
+            id=uuid.uuid4(),
             vector=self.vector,
+            embedding_pk=self.pk,
             metadata={
                 "object_id": str(self.object_id),
                 "content_type_id": str(self.content_type_id),


### PR DESCRIPTION
So that we can rely on Embedding objects being present when we're building backends, this makes Documents have an embedding_pk field which is populated by the Converter.

This also changes all backends so that they return a Document which will retain that reference back to the Embedding.

There's probably more we can do here to enforce this, but this is a starting point.