### PR TITLE
Bug in index.query() prevents content from similar documents to be included in LLM query

### DIFF
--- a/src/wagtail_vector_index/storage/base.py
+++ b/src/wagtail_vector_index/storage/base.py
@@ -134,11 +134,7 @@ class VectorIndex(Generic[ConfigClass]):
         except StopIteration as e:
             raise ValueError("No embeddings were generated for the given query.") from e
 
-        similar_documents = self.get_similar_documents(query_embedding)
-
-        # Perform the similarity search and convert the generator to a list
-        similar_documents_generator = self.backend_index.similarity_search(query_embedding)
-        similar_documents = list(similar_documents_generator)
+        similar_documents = list(self.get_similar_documents(query_embedding))
 
         sources = self._deduplicate_list(
             self.get_converter().bulk_from_documents(similar_documents)

--- a/src/wagtail_vector_index/storage/base.py
+++ b/src/wagtail_vector_index/storage/base.py
@@ -136,6 +136,10 @@ class VectorIndex(Generic[ConfigClass]):
 
         similar_documents = self.get_similar_documents(query_embedding)
 
+        # Perform the similarity search and convert the generator to a list
+        similar_documents_generator = self.backend_index.similarity_search(query_embedding)
+        similar_documents = list(similar_documents_generator)
+
         sources = self._deduplicate_list(
             self.get_converter().bulk_from_documents(similar_documents)
         )


### PR DESCRIPTION
`Index.query()` does not use the content of 'similar documents'. The variable 'merged_context' in `def query()` is always empty. Effectively, this means that the RAG functionality of `index.query()` is not working.

The reason is that 'similar_documents' is of type iterator. After 'similar_documents' is used in 'sources', the iterator cannot be used again in 'merged_context'. The solution is to convert the iterator to a list at an earlier stage.