### PR TITLE
Add async iteration dunder methods to LiteLLMStreamingAIResponse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dependencies = [
     "Django>=4.2",
     "Wagtail>=5.2",
-    "litellm>=1.40.15,<1.40.16",
+    "litellm>=1.41.15",
     "openai>=1.28.1",
     "aiohttp>=3.9.0b0; python_version >= '3.12'",
 ]

--- a/tests/test_ai_utils/test_backends/test_litellm.py
+++ b/tests/test_ai_utils/test_backends/test_litellm.py
@@ -167,6 +167,24 @@ async def test_litellm_async_chat(make_chat_backend):
     assert response.choices[0] == response_text
 
 
+@if_litellm_installed
+async def test_litellm_streaming_async_chat(make_chat_backend):
+    backend = make_chat_backend()
+    input_text = "Little trotty wagtail, he waddled in the mud."
+    response_text = "And left his little footmarks, trample where he would."
+    messages: List[ChatMessage] = [
+        {"content": message, "role": "user"} for message in input_text
+    ]
+    response = await backend.achat(
+        messages=messages, stream=True, mock_response=response_text
+    )
+    full_text = ""
+    async for chunk in response:
+        full_text += chunk["content"]
+
+    assert full_text == response_text
+
+
 ###############################################################################
 # Embeddings
 ###############################################################################


### PR DESCRIPTION
Adds `__aiter__` and `__anext__` methods to `LiteLLMStreamingAIResponse` so that the response can properly be iterated over without using the inner `stream_wrapper`.

Before:

```python
response = await chat_backend.achat(messages=messages, stream=True)

async for chunk in response.stream_wrapper:
    print(chunk)
```

After:

```python
response = await chat_backend.achat(messages=messages, stream=True)

async for chunk in response:
    print(chunk)
```