### PR TITLE
Feature/add litellm chat streaming test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dependencies = [
     "Django>=4.2",
     "Wagtail>=5.2",
-    "litellm>=1.41.15",
+    "litellm>=1.43.2",
     "openai>=1.28.1",
     "aiohttp>=3.9.0b0; python_version >= '3.12'",
 ]

--- a/src/wagtail_vector_index/ai_utils/backends/litellm.py
+++ b/src/wagtail_vector_index/ai_utils/backends/litellm.py
@@ -1,6 +1,7 @@
+import inspect
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, NotRequired, Self
+from typing import Any, Generator, NotRequired, Self
 
 import litellm
 import litellm.types.utils
@@ -40,7 +41,10 @@ class LiteLLMEmbeddingSettingsDict(
 def build_ai_response(response):
     """Convert a LiteLLM response to the appropriate AIResponse class"""
 
-    if type(response) == litellm.CustomStreamWrapper:
+    # Normally, LiteLLM returns a CustomStreamWrapper for streaming calls,
+    # but in some cases such as when passing a mock_response, it returns a generator.
+    # They can both be treated as equivalent for our purposes.
+    if type(response) == litellm.CustomStreamWrapper or inspect.isgenerator(response):
         return LiteLLMStreamingAIResponse(response)
 
     return AIResponse(
@@ -51,7 +55,7 @@ def build_ai_response(response):
 class LiteLLMStreamingAIResponse(AIStreamingResponse):
     """A wrapper around a litellm.CustomStreamWrapper to make it compatible with the AIStreamingResponse interface."""
 
-    def __init__(self, stream_wrapper: litellm.CustomStreamWrapper) -> None:
+    def __init__(self, stream_wrapper: litellm.CustomStreamWrapper | Generator) -> None:
         self.stream_wrapper = stream_wrapper
 
     def __iter__(self):

--- a/src/wagtail_vector_index/ai_utils/backends/litellm.py
+++ b/src/wagtail_vector_index/ai_utils/backends/litellm.py
@@ -1,7 +1,6 @@
-import inspect
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Generator, NotRequired, Self
+from typing import Any, NotRequired, Self
 
 import litellm
 import litellm.types.utils
@@ -41,10 +40,7 @@ class LiteLLMEmbeddingSettingsDict(
 def build_ai_response(response):
     """Convert a LiteLLM response to the appropriate AIResponse class"""
 
-    # Normally, LiteLLM returns a CustomStreamWrapper for streaming calls,
-    # but in some cases such as when passing a mock_response, it returns a generator.
-    # They can both be treated as equivalent for our purposes.
-    if type(response) == litellm.CustomStreamWrapper or inspect.isgenerator(response):
+    if type(response) == litellm.CustomStreamWrapper:
         return LiteLLMStreamingAIResponse(response)
 
     return AIResponse(
@@ -55,7 +51,7 @@ def build_ai_response(response):
 class LiteLLMStreamingAIResponse(AIStreamingResponse):
     """A wrapper around a litellm.CustomStreamWrapper to make it compatible with the AIStreamingResponse interface."""
 
-    def __init__(self, stream_wrapper: litellm.CustomStreamWrapper | Generator) -> None:
+    def __init__(self, stream_wrapper: litellm.CustomStreamWrapper) -> None:
         self.stream_wrapper = stream_wrapper
 
     def __iter__(self):

--- a/tests/test_ai_utils/test_backends/test_litellm.py
+++ b/tests/test_ai_utils/test_backends/test_litellm.py
@@ -157,6 +157,23 @@ def test_litellm_chat(make_chat_backend):
 
 
 @if_litellm_installed
+def test_litellm_streaming_chat(make_chat_backend):
+    backend = make_chat_backend()
+    input_text = "Little trotty wagtail, he waddled in the mud."
+    response_text = "And left his little footmarks, trample where he would."
+    messages: List[ChatMessage] = [
+        {"content": message, "role": "user"} for message in input_text
+    ]
+    response = backend.chat(messages=messages, stream=True, mock_response=response_text)
+
+    full_text = ""
+    for chunk in response:
+        full_text += chunk["content"]
+
+    assert full_text == response_text
+
+
+@if_litellm_installed
 async def test_litellm_async_chat(make_chat_backend):
     backend = make_chat_backend()
     input_text = "Little trotty wagtail, he waddled in the mud."


### PR DESCRIPTION
In some cases, such as when passing a `mock_response` to `completion`, LiteLLM returns a generator rather than a `CustomStreamWrapper`.

This doesn't seem to break anything except for tests, so this just adds a test and a fix for it - likely only useful for future tests.