### PR TITLE
Support specifying a similarity threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ devenv.lock
 devenv.nix
 .env
 .ruff_cache
+.DS_Store

--- a/docs/vector-indexes.md
+++ b/docs/vector-indexes.md
@@ -191,3 +191,71 @@ class MyWeaviateVectorIndex(
 ):
     storage_provider_alias = "weaviate"
 ```
+
+# Using Similarity Threshold in Vector Search
+
+The vector search implementation supports a similarity threshold for filtering results. This feature ensures that only the most relevant documents are returned, improving both the quality of results and query performance.
+
+## Understanding Similarity Threshold
+
+The similarity threshold is a float value between 0 and 1, where:
+- 0 means no threshold (all results are returned, up to the specified limit)
+- 1 means maximum similarity (only exact matches would be returned)
+- Values in between filter results based on their similarity to the query
+
+Higher threshold values result in fewer, but potentially more relevant results.
+
+## Similarity Threshold in Vector Index Methods
+
+The `VectorIndex` class includes a `similarity_threshold` parameter in methods like `query`, `find_similar`, and `search`:
+
+```python
+class MyVectorIndex(EmbeddableFieldsVectorIndexMixin, PgvectorIndexMixin, VectorIndex):
+    def query(self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0) -> QueryResponse:
+        # Implementation here
+
+    def find_similar(self, object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0) -> list:
+        # Implementation here
+
+    def search(self, query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list:
+        # Implementation here
+```
+
+## Example Usage
+
+Here are examples of how to use the `similarity_threshold` parameter:
+
+```python
+index = MyVectorIndex()
+
+# Query with similarity threshold
+response = index.query("What is the capital of France?", similarity_threshold=0.8)
+
+# Find similar objects with similarity threshold
+similar_objects = index.find_similar(my_object, similarity_threshold=0.7)
+
+# Search with similarity threshold
+search_results = index.search("AI in healthcare", similarity_threshold=0.75)
+```
+
+## Best Practices and Considerations
+
+1. **Choosing a Threshold**: Start with a lower threshold (e.g., 0.5) and adjust based on your specific use case and the quality of results.
+
+2. **Performance**: Higher thresholds can improve query performance by reducing the number of results processed.
+
+3. **Result Set Size**: Be aware that high thresholds might significantly reduce the number of results. Always check if your result set is empty and consider lowering the threshold if necessary.
+
+4. **Backend Differences**: While we strive for consistency, different vector search backends (e.g., pgvector, Qdrant, Weaviate) may have slight variations in how similarity is calculated. Test thoroughly with your specific backend.
+
+5. **Combining with Limit**: The `similarity_threshold` works in conjunction with the `limit` parameter. Results are first filtered by the similarity threshold, then limited to the specified number.
+
+## Debugging and Tuning
+
+If you're not getting the expected results:
+
+1. Try lowering the threshold to see if more relevant results appear.
+2. Check the similarity scores of your results (if available) to understand the distribution.
+3. Consider the nature of your data and queries. Some domains might require lower thresholds to capture relevant semantic relationships.
+
+Remember, the optimal threshold can vary depending on your specific use case, data, and the embedding model used. Experimentation and iterative tuning are often necessary to find the best balance between precision and recall for your application.

--- a/docs/vector-indexes.md
+++ b/docs/vector-indexes.md
@@ -192,65 +192,54 @@ class MyWeaviateVectorIndex(
     storage_provider_alias = "weaviate"
 ```
 
-# Using Similarity Threshold in Vector Search
+## Using Similarity Threshold in Vector Search
 
-The vector search implementation supports a similarity threshold for filtering results. This feature ensures that only the most relevant documents are returned, improving both the quality of results and query performance.
+### Understanding Similarity in Vector Search
 
-## Understanding Similarity Threshold
+Vector search operates on the principle of finding documents or items that are "similar" to a given query or reference item. This similarity is typically measured by the distance between vectors in a high-dimensional space. Before we dive into similarity thresholds, it's crucial to understand this concept.
 
-The similarity threshold is a float value between 0 and 1, where:
+### What is a Similarity Threshold?
+
+A similarity threshold is a filtering mechanism in vector search that allows you to control the relevance of returned results. It ensures that only the most pertinent documents are included in the result set, which can improve both the quality of results and query performance.
+
+The similarity threshold is represented as a float value between 0 and 1, where:
+
 - 0 means no threshold (all results are returned, up to the specified limit)
 - 1 means maximum similarity (only exact matches would be returned)
 - Values in between filter results based on their similarity to the query
 
 Higher threshold values result in fewer, but potentially more relevant results.
 
-## Similarity Threshold in Vector Index Methods
+### Implementing Similarity Threshold in Wagtail Vector Index
 
-The `VectorIndex` class includes a `similarity_threshold` parameter in methods like `query`, `find_similar`, and `search`:
+In Wagtail Vector Index, the `VectorIndex` class includes a `similarity_threshold` parameter in key methods:
 
-```python
-class MyVectorIndex(EmbeddableFieldsVectorIndexMixin, PgvectorIndexMixin, VectorIndex):
-    def query(self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0) -> QueryResponse:
-        # Implementation here
+* `query(query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0) -> QueryResponse`:
+  This method is used for querying the vector index.
+* `find_similar(object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0) -> list`:
+  This method finds similar objects in the vector index.
+* `search(query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list`:
+  This method performs a search in the vector index.
 
-    def find_similar(self, object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0) -> list:
-        # Implementation here
+Each of these methods includes a `similarity_threshold` parameter, allowing you to control the similarity threshold for that specific operation.
 
-    def search(self, query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list:
-        # Implementation here
-```
-
-## Example Usage
-
-Here are examples of how to use the `similarity_threshold` parameter:
-
-```python
-index = MyVectorIndex()
-
-# Query with similarity threshold
-response = index.query("What is the capital of France?", similarity_threshold=0.8)
-
-# Find similar objects with similarity threshold
-similar_objects = index.find_similar(my_object, similarity_threshold=0.7)
-
-# Search with similarity threshold
-search_results = index.search("AI in healthcare", similarity_threshold=0.75)
-```
-
-## Best Practices and Considerations
+### Best Practices and Considerations
 
 1. **Choosing a Threshold**: Start with a lower threshold (e.g., 0.5) and adjust based on your specific use case and the quality of results.
-
-2. **Performance**: Higher thresholds can improve query performance by reducing the number of results processed.
-
+2. **Performance Impact**: Higher thresholds can improve query performance by reducing the number of results processed.
 3. **Result Set Size**: Be aware that high thresholds might significantly reduce the number of results. Always check if your result set is empty and consider lowering the threshold if necessary.
-
 4. **Backend Differences**: While we strive for consistency, different vector search backends (e.g., pgvector, Qdrant, Weaviate) may have slight variations in how similarity is calculated. Test thoroughly with your specific backend.
-
 5. **Combining with Limit**: The `similarity_threshold` works in conjunction with the `limit` parameter. Results are first filtered by the similarity threshold, then limited to the specified number.
 
-## Debugging and Tuning
+## Practical Applications
+
+Consider these scenarios where adjusting the similarity threshold can be beneficial:
+
+1. **Content Recommendations**: In a content recommendation system, you might start with a lower threshold to cast a wide net, then gradually increase it as you gather more user data and refine your recommendations.
+2. **Semantic Search**: For a semantic search engine, a higher threshold can help ensure that only truly relevant results are returned, improving the user experience.
+3. **Duplicate Detection**: When looking for near-duplicate content, a very high threshold might be appropriate to catch only the closest matches.
+
+### Debugging and Tuning
 
 If you're not getting the expected results:
 
@@ -259,3 +248,5 @@ If you're not getting the expected results:
 3. Consider the nature of your data and queries. Some domains might require lower thresholds to capture relevant semantic relationships.
 
 Remember, the optimal threshold can vary depending on your specific use case, data, and the embedding model used. Experimentation and iterative tuning are often necessary to find the best balance between precision and recall for your application.
+
+For code examples and step-by-step guides on using similarity thresholds, please refer to our How-To Guide: [Using Similarity Thresholds in Wagtail Vector Index](./how-to/using-similarity-thresholds.md).

--- a/docs/vector-indexes.md
+++ b/docs/vector-indexes.md
@@ -200,44 +200,41 @@ Vector search operates on the principle of finding documents or items that are "
 
 ### What is a Similarity Threshold?
 
-A similarity threshold is a filtering mechanism in vector search that allows you to control the relevance of returned results. It ensures that only the most pertinent documents are included in the result set, which can improve both the quality of results and query performance.
+A similarity threshold in vector search helps control the relevance of results. It filters out less relevant documents, improving result quality and query performance.
 
-The similarity threshold is represented as a float value between 0 and 1, where:
+The similarity threshold represents a float value between 0 and 1, indicating the degree of similarity.
 
-- 0 means no threshold (all results are returned, up to the specified limit)
-- 1 means maximum similarity (only exact matches would be returned)
+- 0 means no threshold (the system returns all results within the specified limit.)
+- 1 means maximum similarity (the system returns only exact matches)
 - Values in between filter results based on their similarity to the query
 
-Higher threshold values result in fewer, but potentially more relevant results.
+The similarity threshold has a significant impact on the number of returned results. Higher threshold values lead to fewer results, but these are potentially more relevant, highlighting the trade-off between result quantity and relevance.
 
 ### Implementing Similarity Threshold in Wagtail Vector Index
 
 In Wagtail Vector Index, the `VectorIndex` class includes a `similarity_threshold` parameter in key methods:
 
-* `query(query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0) -> QueryResponse`:
-  This method is used for querying the vector index.
-* `find_similar(object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0) -> list`:
-  This method finds similar objects in the vector index.
-* `search(query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list`:
-  This method performs a search in the vector index.
+* `query`: This method is used for querying the vector index.
+* `find_similar`: This method finds similar objects in the vector index.
+* `search`: This method performs a search in the vector index.
 
 Each of these methods includes a `similarity_threshold` parameter, allowing you to control the similarity threshold for that specific operation.
 
 ### Best Practices and Considerations
 
 1. **Choosing a Threshold**: Start with a lower threshold (e.g., 0.5) and adjust based on your specific use case and the quality of results.
-2. **Performance Impact**: Higher thresholds can improve query performance by reducing the number of results processed.
-3. **Result Set Size**: Be aware that high thresholds might significantly reduce the number of results. Always check if your result set is empty and consider lowering the threshold if necessary.
-4. **Backend Differences**: While we strive for consistency, different vector search backends (e.g., pgvector, Qdrant, Weaviate) may have slight variations in how similarity is calculated. Test thoroughly with your specific backend.
-5. **Combining with Limit**: The `similarity_threshold` works in conjunction with the `limit` parameter. Results are first filtered by the similarity threshold, then limited to the specified number.
+2. Performance Impact: Optimistically, higher thresholds can significantly improve query performance by reducing the number of results processed. This potential for optimization is a key advantage of vector search.
+3. **Result Set Size**: Be aware that high thresholds might significantly reduce the number of results. Always check if your result set is empty, and consider lowering the threshold if necessary.
+4. **Backend Differences**: While we strive for consistency, different vector search backends (e.g., pgvector, Qdrant, Weaviate) may calculate similarity slightly differently. Test thoroughly with your specific backend.
+5. **Combining with Limit**: The `similarity_threshold` parameter works in conjunction with the `limit` parameter. Results are first filtered by the similarity threshold and then limited to the specified number.
 
 ## Practical Applications
 
 Consider these scenarios where adjusting the similarity threshold can be beneficial:
 
-1. **Content Recommendations**: In a content recommendation system, you might start with a lower threshold to cast a wide net, then gradually increase it as you gather more user data and refine your recommendations.
-2. **Semantic Search**: For a semantic search engine, a higher threshold can help ensure that only truly relevant results are returned, improving the user experience.
-3. **Duplicate Detection**: When looking for near-duplicate content, a very high threshold might be appropriate to catch only the closest matches.
+1. **Content Recommendations**: In a content recommendation system, starting with a lower threshold to cast a wide net and then gradually increasing it as you gather more user data underscores the value of your work in refining recommendations.
+2. **Semantic Search**: A higher threshold in a semantic search engine can ensure that it returns more relevant results, thereby improving the user experience.
+3. **Duplicate Detection: A very high threshold is appropriate to catch only the closest matches when looking for near-duplicate content.
 
 ### Debugging and Tuning
 
@@ -245,8 +242,6 @@ If you're not getting the expected results:
 
 1. Try lowering the threshold to see if more relevant results appear.
 2. Check the similarity scores of your results (if available) to understand the distribution.
-3. Consider the nature of your data and queries. Some domains might require lower thresholds to capture relevant semantic relationships.
+3. Consider the nature of your data and queries. Some domains require lower thresholds to capture relevant semantic relationships.
 
-Remember, the optimal threshold can vary depending on your specific use case, data, and the embedding model used. Experimentation and iterative tuning are often necessary to find the best balance between precision and recall for your application.
-
-For code examples and step-by-step guides on using similarity thresholds, please refer to our How-To Guide: [Using Similarity Thresholds in Wagtail Vector Index](./how-to/using-similarity-thresholds.md).
+Remember, the optimal threshold can vary depending on your specific use case, data, and embedding model. Experimentation and iterative tuning are often necessary to find the best balance between precision and recall for your application.

--- a/src/wagtail_vector_index/storage/base.py
+++ b/src/wagtail_vector_index/storage/base.py
@@ -138,7 +138,7 @@ class VectorIndex(Generic[ConfigClass]):
     # Public API
 
     def query(
-        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default"
+        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0
     ) -> QueryResponse:
         """Perform a natural language query against the index, returning a QueryResponse containing the natural language response, and a list of sources"""
         try:
@@ -146,7 +146,7 @@ class VectorIndex(Generic[ConfigClass]):
         except StopIteration as e:
             raise ValueError("No embeddings were generated for the given query.") from e
 
-        similar_documents = list(self.get_similar_documents(query_embedding))
+        similar_documents = list(self.get_similar_documents(query_embedding, similarity_threshold=similarity_threshold))
 
         sources = list(self.get_converter().bulk_from_documents(similar_documents))
 
@@ -165,7 +165,7 @@ class VectorIndex(Generic[ConfigClass]):
         return QueryResponse(response=response.choices[0], sources=sources)
 
     async def aquery(
-        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default"
+        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0
     ) -> AsyncQueryResponse:
         """
         Replicates the features of `VectorIndex.query()`, but in an async way.
@@ -176,7 +176,7 @@ class VectorIndex(Generic[ConfigClass]):
             raise ValueError("No embeddings were generated for the given query.") from e
 
         similar_documents = [
-            doc async for doc in self.aget_similar_documents(query_embedding)
+            doc async for doc in self.aget_similar_documents(query_embedding, similarity_threshold=similarity_threshold)
         ]
 
         sources = [
@@ -209,7 +209,7 @@ class VectorIndex(Generic[ConfigClass]):
         )
 
     def find_similar(
-        self, object, *, include_self: bool = False, limit: int = 5
+        self, object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0
     ) -> list:
         """Find similar objects to the given object"""
         converter = self.get_converter()
@@ -219,7 +219,7 @@ class VectorIndex(Generic[ConfigClass]):
         similar_documents = []
         for document in object_documents:
             similar_documents += self.get_similar_documents(
-                document.vector, limit=limit
+                document.vector, limit=limit, similarity_threshold=similarity_threshold
             )
 
         return [
@@ -228,13 +228,13 @@ class VectorIndex(Generic[ConfigClass]):
             if include_self or obj != object
         ]
 
-    def search(self, query: str, *, limit: int = 5) -> list:
+    def search(self, query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list:
         """Perform a search against the index, returning only a list of matching sources"""
         try:
             query_embedding = next(self.get_embedding_backend().embed([query]))
         except StopIteration as e:
             raise ValueError("No embeddings were generated for the given query.") from e
-        similar_documents = self.get_similar_documents(query_embedding, limit=limit)
+        similar_documents = self.get_similar_documents(query_embedding, limit=limit, similarity_threshold=similarity_threshold)
         return list(self.get_converter().bulk_from_documents(similar_documents))
 
     # Utilities
@@ -262,11 +262,11 @@ class VectorIndex(Generic[ConfigClass]):
         raise NotImplementedError
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5
+        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
     ) -> Generator[Document, None, None]:
         raise NotImplementedError
 
     def aget_similar_documents(
-        self, query_vector, *, limit: int = 5
+        self, query_vector, *, limit: int = 5, similarity_threshold: float = 0.0
     ) -> AsyncGenerator[Document, None]:
         raise NotImplementedError

--- a/src/wagtail_vector_index/storage/base.py
+++ b/src/wagtail_vector_index/storage/base.py
@@ -138,7 +138,12 @@ class VectorIndex(Generic[ConfigClass]):
     # Public API
 
     def query(
-        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0
+        self,
+        query: str,
+        *,
+        sources_limit: int = 5,
+        chat_backend_alias: str = "default",
+        similarity_threshold: float = 0.0,
     ) -> QueryResponse:
         """Perform a natural language query against the index, returning a QueryResponse containing the natural language response, and a list of sources"""
         try:
@@ -146,7 +151,11 @@ class VectorIndex(Generic[ConfigClass]):
         except StopIteration as e:
             raise ValueError("No embeddings were generated for the given query.") from e
 
-        similar_documents = list(self.get_similar_documents(query_embedding, similarity_threshold=similarity_threshold))
+        similar_documents = list(
+            self.get_similar_documents(
+                query_embedding, similarity_threshold=similarity_threshold
+            )
+        )
 
         sources = list(self.get_converter().bulk_from_documents(similar_documents))
 
@@ -165,7 +174,12 @@ class VectorIndex(Generic[ConfigClass]):
         return QueryResponse(response=response.choices[0], sources=sources)
 
     async def aquery(
-        self, query: str, *, sources_limit: int = 5, chat_backend_alias: str = "default", similarity_threshold: float = 0.0
+        self,
+        query: str,
+        *,
+        sources_limit: int = 5,
+        chat_backend_alias: str = "default",
+        similarity_threshold: float = 0.0,
     ) -> AsyncQueryResponse:
         """
         Replicates the features of `VectorIndex.query()`, but in an async way.
@@ -176,7 +190,10 @@ class VectorIndex(Generic[ConfigClass]):
             raise ValueError("No embeddings were generated for the given query.") from e
 
         similar_documents = [
-            doc async for doc in self.aget_similar_documents(query_embedding, similarity_threshold=similarity_threshold)
+            doc
+            async for doc in self.aget_similar_documents(
+                query_embedding, similarity_threshold=similarity_threshold
+            )
         ]
 
         sources = [
@@ -209,7 +226,12 @@ class VectorIndex(Generic[ConfigClass]):
         )
 
     def find_similar(
-        self, object, *, include_self: bool = False, limit: int = 5, similarity_threshold: float = 0.0
+        self,
+        object,
+        *,
+        include_self: bool = False,
+        limit: int = 5,
+        similarity_threshold: float = 0.0,
     ) -> list:
         """Find similar objects to the given object"""
         converter = self.get_converter()
@@ -228,13 +250,17 @@ class VectorIndex(Generic[ConfigClass]):
             if include_self or obj != object
         ]
 
-    def search(self, query: str, *, limit: int = 5, similarity_threshold: float = 0.0) -> list:
+    def search(
+        self, query: str, *, limit: int = 5, similarity_threshold: float = 0.0
+    ) -> list:
         """Perform a search against the index, returning only a list of matching sources"""
         try:
             query_embedding = next(self.get_embedding_backend().embed([query]))
         except StopIteration as e:
             raise ValueError("No embeddings were generated for the given query.") from e
-        similar_documents = self.get_similar_documents(query_embedding, limit=limit, similarity_threshold=similarity_threshold)
+        similar_documents = self.get_similar_documents(
+            query_embedding, limit=limit, similarity_threshold=similarity_threshold
+        )
         return list(self.get_converter().bulk_from_documents(similar_documents))
 
     # Utilities
@@ -262,7 +288,11 @@ class VectorIndex(Generic[ConfigClass]):
         raise NotImplementedError
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
+        self,
+        query_vector: Sequence[float],
+        *,
+        limit: int = 5,
+        similarity_threshold: float = 0.0,
     ) -> Generator[Document, None, None]:
         raise NotImplementedError
 

--- a/src/wagtail_vector_index/storage/numpy/provider.py
+++ b/src/wagtail_vector_index/storage/numpy/provider.py
@@ -35,7 +35,11 @@ class NumpyIndexMixin(MixinBase):
         pass
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
+        self,
+        query_vector: Sequence[float],
+        *,
+        limit: int = 5,
+        similarity_threshold: float = 0.0,
     ) -> Generator[Document, None, None]:
         similarities = []
         for document in self.get_documents():

--- a/src/wagtail_vector_index/storage/numpy/provider.py
+++ b/src/wagtail_vector_index/storage/numpy/provider.py
@@ -35,7 +35,7 @@ class NumpyIndexMixin(MixinBase):
         pass
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5
+        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
     ) -> Generator[Document, None, None]:
         similarities = []
         for document in self.get_documents():
@@ -44,7 +44,8 @@ class NumpyIndexMixin(MixinBase):
                 / np.linalg.norm(query_vector)
                 * np.linalg.norm(document.vector)
             )
-            similarities.append((cosine_similarity, document))
+            if cosine_similarity >= similarity_threshold:
+                similarities.append((cosine_similarity, document))
 
         sorted_similarities = sorted(
             similarities, key=lambda pair: pair[0], reverse=True

--- a/src/wagtail_vector_index/storage/qdrant/provider.py
+++ b/src/wagtail_vector_index/storage/qdrant/provider.py
@@ -61,7 +61,11 @@ class QdrantIndexMixin(MixinBase):
         )
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
+        self,
+        query_vector: Sequence[float],
+        *,
+        limit: int = 5,
+        similarity_threshold: float = 0.0,
     ) -> Generator[Document, None, None]:
         """
         Retrieve similar documents from Qdrant.
@@ -92,7 +96,7 @@ class QdrantIndexMixin(MixinBase):
             collection_name=self.index_name,
             query_vector=query_vector,
             limit=limit,
-            score_threshold=score_threshold
+            score_threshold=score_threshold,
         )
         for doc in similar_documents:
             yield Document(

--- a/src/wagtail_vector_index/storage/weaviate/provider.py
+++ b/src/wagtail_vector_index/storage/weaviate/provider.py
@@ -100,7 +100,7 @@ class WeaviateIndexMixin(MixinBase):
             "vector": query_vector,
         }
         if distance_threshold is not None:
-            near_vector["distance"] = distance_threshold
+            near_vector["distance"] = [distance_threshold]
 
         similar_documents = (
             self.storage_provider.client.query.get(

--- a/src/wagtail_vector_index/storage/weaviate/provider.py
+++ b/src/wagtail_vector_index/storage/weaviate/provider.py
@@ -63,7 +63,11 @@ class WeaviateIndexMixin(MixinBase):
         raise NotImplementedError
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
+        self,
+        query_vector: Sequence[float],
+        *,
+        limit: int = 5,
+        similarity_threshold: float = 0.0,
     ) -> Generator[Document, None, None]:
         """
         Retrieve similar documents from Weaviate.
@@ -80,7 +84,7 @@ class WeaviateIndexMixin(MixinBase):
 
         Note:
             Weaviate uses cosine distance internally, where lower values indicate
-            more similar vectors. The similarity_threshold is converted to a 
+            more similar vectors. The similarity_threshold is converted to a
             distance threshold where distance = 1 - similarity.
         """
         if not 0 <= similarity_threshold <= 1:
@@ -88,7 +92,9 @@ class WeaviateIndexMixin(MixinBase):
 
         # Convert similarity threshold to distance threshold
         # Weaviate uses cosine distance, which is 1 - cosine similarity
-        distance_threshold = 1 - similarity_threshold if similarity_threshold > 0 else None
+        distance_threshold = (
+            1 - similarity_threshold if similarity_threshold > 0 else None
+        )
 
         near_vector = {
             "vector": query_vector,

--- a/src/wagtail_vector_index/storage/weaviate/provider.py
+++ b/src/wagtail_vector_index/storage/weaviate/provider.py
@@ -63,11 +63,39 @@ class WeaviateIndexMixin(MixinBase):
         raise NotImplementedError
 
     def get_similar_documents(
-        self, query_vector: Sequence[float], *, limit: int = 5
+        self, query_vector: Sequence[float], *, limit: int = 5, similarity_threshold: float = 0.0
     ) -> Generator[Document, None, None]:
+        """
+        Retrieve similar documents from Weaviate.
+
+        Args:
+            query_vector (Sequence[float]): The query vector to find similar documents for.
+            limit (int): The maximum number of similar documents to return. Defaults to 5.
+            similarity_threshold (float): The minimum similarity for returned documents.
+                                        Range is [0, 1] where 1 is most similar.
+                                        0 means no threshold (default).
+
+        Returns:
+            Generator[Document, None, None]: A generator of similar documents.
+
+        Note:
+            Weaviate uses cosine distance internally, where lower values indicate
+            more similar vectors. The similarity_threshold is converted to a 
+            distance threshold where distance = 1 - similarity.
+        """
+        if not 0 <= similarity_threshold <= 1:
+            raise ValueError("similarity_threshold must be between 0 and 1")
+
+        # Convert similarity threshold to distance threshold
+        # Weaviate uses cosine distance, which is 1 - cosine similarity
+        distance_threshold = 1 - similarity_threshold if similarity_threshold > 0 else None
+
         near_vector = {
             "vector": query_vector,
         }
+        if distance_threshold is not None:
+            near_vector["distance"] = distance_threshold
+
         similar_documents = (
             self.storage_provider.client.query.get(
                 self.index_name,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -14,20 +14,24 @@ from wagtail_vector_index.storage.models import EmbeddingField
 fake = Faker()
 
 
+def get_vector_for_text(text):
+    if "Very similar" in text:
+        return [0.9, 0.1, 0.0]
+    elif "Somewhat similar" in text:
+        return [0.7, 0.3, 0.0]
+    elif "test" in text.lower():
+        return [1.0, 0.0, 0.0]
+    else:
+        return [0.1, 0.1, 0.8]
+
+
 @pytest.fixture
 def mock_embedding_backend():
     class MockEmbeddingBackend(BaseEmbeddingBackend):
         def embed(self, texts):
             def embedding_generator():
                 for text in texts:
-                    if "test" in text.lower():
-                        yield [1.0, 0.0, 0.0]
-                    elif "Very similar" in text:
-                        yield [0.9, 0.1, 0.0]
-                    elif "Somewhat similar" in text:
-                        yield [0.7, 0.3, 0.0]
-                    else:
-                        yield [0.1, 0.1, 0.8]
+                    yield get_vector_for_text(text)
 
             return embedding_generator()
 
@@ -47,12 +51,7 @@ def test_pages():
 def document_generator(test_pages):
     def gen_documents(cls, *args, **kwargs):
         for page in test_pages:
-            if "Very similar" in page.title:
-                vector = [0.9, 0.1, 0.0]
-            elif "Somewhat similar" in page.title:
-                vector = [0.7, 0.3, 0.0]
-            else:
-                vector = [0.1, 0.1, 0.8]
+            vector = get_vector_for_text(page.title)
             yield Document(
                 embedding_pk=page.pk,
                 metadata={

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -236,19 +236,17 @@ def test_find_similar_with_similarity_threshold(mocker):
         side_effect=gen_pages,
     )
 
-    case = unittest.TestCase()
-
     # We expect 9 results without the page itself.
     actual = vector_index.find_similar(
         pages[0], limit=100, include_self=False, similarity_threshold=0.5
     )
-    case.assertCountEqual(actual, pages[1:])
+    assert set(actual) == set(pages[1:]), f"Expected {pages[1:]}, but got {actual}"
 
     # We expect 10 results with the page itself.
     actual = vector_index.find_similar(
         pages[0], limit=100, include_self=True, similarity_threshold=0.5
     )
-    case.assertCountEqual(actual, pages)
+    assert set(actual) == set(pages), f"Expected {pages}, but got {actual}"
 
 
 @pytest.mark.django_db

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -124,7 +124,7 @@ def test_query_passes_sources_to_backend(mocker):
     index = ExamplePage.vector_index
     documents = index.get_documents()[:2]
 
-    def get_similar_documents(query_embedding, limit=0):
+    def get_similar_documents(query_embedding, limit=0, similarity_score=0.0):
         yield from documents
 
     query_mock = mocker.patch("conftest.ChatMockBackend.chat")


### PR DESCRIPTION
Related to #21

Add support for specifying a similarity threshold in vector search methods.

* **VectorIndex Class**: Add `similarity_threshold` parameter to `query`, `find_similar`, and `search` methods in `src/wagtail_vector_index/storage/base.py`.
* **PgvectorIndexMixin Class**: Update `get_similar_documents` and `aget_similar_documents` methods to accept `similarity_threshold` parameter and filter results based on it in `src/wagtail_vector_index/storage/pgvector/provider.py`.
* **QdrantIndexMixin Class**: Update `get_similar_documents` method to accept `similarity_threshold` parameter and filter results based on it in `src/wagtail_vector_index/storage/qdrant/provider.py`.
* **WeaviateIndexMixin Class**: Update `get_similar_documents` method to accept `similarity_threshold` parameter and filter results based on it in `src/wagtail_vector_index/storage/weaviate/provider.py`.
* **NumpyIndexMixin Class**: Update `get_similar_documents` method to accept `similarity_threshold` parameter and filter results based on it in `src/wagtail_vector_index/storage/numpy/provider.py`.
* **Documentation**: Update `docs/vector-indexes.md` to include information on the new `similarity_threshold` parameter and provide examples of its usage.
* **Tests**: Add tests for the new `similarity_threshold` parameter in `query`, `find_similar`, and `search` methods in `tests/test_index.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wagtail/wagtail-vector-index/issues/21?shareId=c122e9f4-e046-4a9d-ad8c-9792d2c6cf9a).